### PR TITLE
Change read consistency level to linearizable

### DIFF
--- a/rqlitekv/rqlite.go
+++ b/rqlitekv/rqlite.go
@@ -16,7 +16,7 @@ func New(client *rqlitehttp.Client) *Rqlite {
 	return &Rqlite{
 		Client:          client,
 		Timeout:         time.Second * 10,
-		ReadConsistency: rqlitehttp.ReadConsistencyLevelStrong,
+		ReadConsistency: rqlitehttp.ReadConsistencyLevelLinearizable,
 		Now:             time.Now,
 	}
 }


### PR DESCRIPTION
Don't use Strong for production systems, use Linearizable. You get the same guarantees, but at much less cost.

https://rqlite.io/docs/api/read-consistency/#linearizable

https://rqlite.io/docs/api/read-consistency/#strong

_Strong consistency has little use in production systems, as the reads are costly, consume disk space, and do not offer any benefit over Linearizable reads. Don’t use Strong in production. Strong reads can be useful in certain testing scenarios however._
